### PR TITLE
feat: add password reset functionality and improve forgot password sc…

### DIFF
--- a/money_mingle/lib/domain/services/auth_service.dart
+++ b/money_mingle/lib/domain/services/auth_service.dart
@@ -36,6 +36,10 @@ class AuthService {
   Future<fb.UserCredential> register(String email, String password) async {
     return await _auth.createUserWithEmailAndPassword(email: email, password: password);
   }
+  // Restablecer contraseña
+  Future<void> resetPassword(String email) async {
+    await _auth.sendPasswordResetEmail(email: email);
+  }
 
   // Iniciar sesión con Google
   Future<fb.UserCredential> signInWithGoogle() async {

--- a/money_mingle/lib/ui/pages/auth/forgot_password_screen.dart
+++ b/money_mingle/lib/ui/pages/auth/forgot_password_screen.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:money_mingle/ui/widgets/shared/custom_button.dart';
+import 'package:money_mingle/providers/auth_providers.dart';
 
-class ForgotPasswordScreen extends StatelessWidget {
+class ForgotPasswordScreen extends ConsumerWidget {
   const ForgotPasswordScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final emailController = TextEditingController();
 
     return Scaffold(
       appBar: AppBar(
@@ -20,24 +23,40 @@ class ForgotPasswordScreen extends StatelessWidget {
             Text("¿Olvidaste tu contraseña?",
                 style: theme.textTheme.headlineSmall),
             const SizedBox(height: 8),
-            Text("Ingresa tu correo electrónico y te enviaremos un enlace para recuperarla.",
-                style: theme.textTheme.bodyMedium),
-            const SizedBox(height: 24),
-
-            TextField(
-              decoration: const InputDecoration(labelText: "Correo electrónico"),
+            Text(
+              "Ingresa tu correo electrónico y te enviaremos un enlace para recuperarla.",
+              style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 24),
-
+            TextField(
+              controller: emailController,
+              decoration: const InputDecoration(labelText: "Correo electrónico"),
+              keyboardType: TextInputType.emailAddress,
+            ),
+            const SizedBox(height: 24),
             SizedBox(
               width: double.infinity,
               child: CustomButton(
                 text: "Enviar enlace de recuperación",
-                onPressed: () {
-                  // Simulación de recuperación
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text("Correo de recuperación enviado (simulado)")),
-                  );
+                onPressed: () async {
+                  final email = emailController.text.trim();
+                  if (email.isEmpty) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text("Por favor ingresa tu correo electrónico")),
+                    );
+                    return;
+                  }
+                  final authService = ref.read(authServiceProvider);
+                  try {
+                    await authService.resetPassword(email);
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text("Correo de recuperación enviado")),
+                    );
+                  } catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text("Error: ${e.toString()}")),
+                    );
+                  }
                 },
               ),
             ),

--- a/money_mingle/lib/ui/pages/auth/register_screen.dart
+++ b/money_mingle/lib/ui/pages/auth/register_screen.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:money_mingle/domain/services/auth_service.dart';
 import 'package:money_mingle/providers/auth_providers.dart';
-//import 'package:money_mingle/providers/user_provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-//import 'package:money_mingle/models/user.dart' as app_model;
 import 'package:money_mingle/ui/widgets/shared/custom_button.dart';
 
 class RegisterScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
This pull request introduces a new password reset functionality and refactors the `ForgotPasswordScreen` to integrate with Riverpod for state management. Additionally, minor cleanup was performed in the `RegisterScreen`. 

### Password Reset Functionality
* Added a new method `resetPassword` in `AuthService` to send a password reset email using Firebase Authentication. (`money_mingle/lib/domain/services/auth_service.dart`, [money_mingle/lib/domain/services/auth_service.dartR39-R42](diffhunk://#diff-b05e16a6ac1def805ecdbd5a039fb03299b6274c3147d68cec8c34ba706a6cf9R39-R42))

### Integration with Riverpod and UI Enhancements
* Refactored `ForgotPasswordScreen` to use `ConsumerWidget`, enabling dependency injection with Riverpod. Introduced `emailController` for managing email input and integrated `authServiceProvider` to handle password reset logic. Added error handling and user feedback for invalid or empty email inputs. (`money_mingle/lib/ui/pages/auth/forgot_password_screen.dart`, [[1]](diffhunk://#diff-63ac468d6c38eb6fa7211fb6fc3ca2cce16738d49613ca027ee027caa51e8135R2-R12) [[2]](diffhunk://#diff-63ac468d6c38eb6fa7211fb6fc3ca2cce16738d49613ca027ee027caa51e8135L23-R59)

### Code Cleanup
* Removed commented-out imports in `RegisterScreen` for better code readability. (`money_mingle/lib/ui/pages/auth/register_screen.dart`, [money_mingle/lib/ui/pages/auth/register_screen.dartL5-L7](diffhunk://#diff-89398a8149635a79ea5cca777adb35ba4fca49fade0c1fc2bde223acdd4e3c75L5-L7))…reen