### PR TITLE
feat: refactor SettingsScreen and implement SingOut functionality

### DIFF
--- a/money_mingle/lib/ui/pages/settings/settings_screen.dart
+++ b/money_mingle/lib/ui/pages/settings/settings_screen.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:money_mingle/app_theme.dart';
+import 'package:money_mingle/providers/auth_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
 
     return Scaffold(
       appBar: AppBar(
@@ -75,8 +77,10 @@ class SettingsScreen extends StatelessWidget {
                       child: const Text('Cancelar'),
                     ),
                     TextButton(
-                      onPressed: () {
+                      onPressed: () async {
                         Navigator.pop(context);
+                        final authService = ref.read(authServiceProvider);
+                        await authService.signOut();
                         Navigator.pushNamedAndRemoveUntil(context, '/login', (route) => false);
                       },
                       child: const Text('Cerrar Sesión'),


### PR DESCRIPTION
This pull request refactors the `SettingsScreen` in the `money_mingle` project to integrate Riverpod state management and improve the handling of user authentication. The most important changes involve replacing the `SettingsScreen` class with a `ConsumerWidget` and implementing the `signOut` functionality using the Riverpod provider.

### Integration of Riverpod State Management:

* [`money_mingle/lib/ui/pages/settings/settings_screen.dart`](diffhunk://#diff-ff219ce484f19576e93a95d4f5c9f5a5c274dc528c0066ad4e89771d915ac4caR3-R10): Changed the `SettingsScreen` class from `StatelessWidget` to `ConsumerWidget` to enable access to Riverpod's `WidgetRef`. Updated the `build` method to include the `WidgetRef` parameter, allowing interaction with providers.

### Authentication Improvements:

* [`money_mingle/lib/ui/pages/settings/settings_screen.dart`](diffhunk://#diff-ff219ce484f19576e93a95d4f5c9f5a5c274dc528c0066ad4e89771d915ac4caL78-R83): Modified the "Cerrar Sesión" button's `onPressed` callback to use the `authServiceProvider` from Riverpod. Added asynchronous logic to sign out the user via `authService.signOut()` and navigate to the login screen.…n-out functionality