### PR TITLE
listo budget y goals en firestore

### DIFF
--- a/money_mingle/lib/ui/pages/budget/budget_form.dart
+++ b/money_mingle/lib/ui/pages/budget/budget_form.dart
@@ -1,4 +1,6 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:money_mingle/domain/services/user_service.dart';
 import 'package:money_mingle/ui/widgets/shared/custom_textfield.dart';
 import 'package:money_mingle/ui/widgets/shared/custom_button.dart';
 import 'package:money_mingle/ui/pages/transaction/widgets/date_field.dart';
@@ -13,11 +15,43 @@ class BudgetForm extends StatefulWidget {
 class _BudgetFormState extends State<BudgetForm> {
   DateTime? _selectedDate;
   final _amountController = TextEditingController();
+  final _userService = UserService();
 
   @override
   void dispose() {
     _amountController.dispose();
     super.dispose();
+  }
+
+  Future<void> _saveBudget() async {
+    final raw = _amountController.text.trim();
+    if (_selectedDate == null || raw.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Selecciona fecha y monto')),
+      );
+      return;
+    }
+    final amount = double.tryParse(raw);
+    if (amount == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Monto inválido')),
+      );
+      return;
+    }
+
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      return;
+    }
+
+    await _userService.updateUserField(uid, 'monthlyBudget', amount);
+    await _userService.updateUserField(
+        uid, 'budgetDate', _selectedDate!.toIso8601String());
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Presupuesto guardado correctamente')),
+    );
+    Navigator.pop(context);
   }
 
   @override
@@ -40,15 +74,14 @@ class _BudgetFormState extends State<BudgetForm> {
               controller: _amountController,
               label: 'Monto del presupuesto',
               icon: Icons.attach_money,
+             
             ),
 
             const SizedBox(height: 24),
 
             CustomButton(
               text: 'Guardar Presupuesto',
-              onPressed: () {
-                // TODO: guardar...
-              },
+              onPressed: _saveBudget,
             ),
           ],
         ),

--- a/money_mingle/lib/ui/pages/budget/goals_form.dart
+++ b/money_mingle/lib/ui/pages/budget/goals_form.dart
@@ -1,4 +1,6 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:money_mingle/domain/services/user_service.dart';
 import 'package:money_mingle/ui/widgets/shared/custom_textfield.dart';
 import 'package:money_mingle/ui/widgets/shared/custom_button.dart';
 import 'package:money_mingle/ui/pages/transaction/widgets/date_field.dart';
@@ -11,15 +13,50 @@ class GoalsForm extends StatefulWidget {
 }
 
 class _GoalsFormState extends State<GoalsForm> {
-  final _titleController  = TextEditingController();
+  final _titleController = TextEditingController();
   final _targetController = TextEditingController();
   DateTime? _dueDate;
+  final _userService = UserService();
 
   @override
   void dispose() {
     _titleController.dispose();
     _targetController.dispose();
     super.dispose();
+  }
+
+  Future<void> _saveGoal() async {
+    final title = _titleController.text.trim();
+    final rawTarget = _targetController.text.trim();
+    if (title.isEmpty || rawTarget.isEmpty || _dueDate == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Completa todos los campos')),
+      );
+      return;
+    }
+    final target = double.tryParse(rawTarget);
+    if (target == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Objetivo inválido')),
+      );
+      return;
+    }
+
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+
+    // Aquí puedes:
+    // 1) Simplemente actualizar savingsGoal en el documento de usuario:
+    await _userService.updateUserField(uid, 'savingsGoal', target);
+    await _userService.updateUserField(
+        uid, 'goalTitle', title);
+    await _userService.updateUserField(
+        uid, 'goalDueDate', _dueDate!.toIso8601String());
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Meta guardada correctamente')),
+    );
+    Navigator.pop(context);
   }
 
   @override
@@ -56,9 +93,7 @@ class _GoalsFormState extends State<GoalsForm> {
 
             CustomButton(
               text: 'Agregar Meta',
-              onPressed: () {
-                // TODO: guardar...
-              },
+              onPressed: _saveGoal,
             ),
           ],
         ),


### PR DESCRIPTION
This pull request introduces functionality to save user budget and goals data in the `BudgetForm` and `GoalsForm` pages. It integrates Firebase authentication and a `UserService` to handle updates to user fields. The most important changes include adding methods to save budget and goal information, updating button actions to invoke these methods, and importing necessary dependencies.

### Budget Form Updates:
* Added `_saveBudget` method to validate input, retrieve the user's UID, and update the `monthlyBudget` and `budgetDate` fields in the user's Firebase document.
* Modified the "Guardar Presupuesto" button to call `_saveBudget` instead of a placeholder action.
* Imported `FirebaseAuth` and `UserService` for authentication and user data handling.

### Goals Form Updates:
* Added `_saveGoal` method to validate input, retrieve the user's UID, and update `savingsGoal`, `goalTitle`, and `goalDueDate` fields in the user's Firebase document.
* Modified the "Agregar Meta" button to call `_saveGoal` instead of a placeholder action.
* Imported `FirebaseAuth` and `UserService` for authentication and user data handling.